### PR TITLE
Allow both pull requests and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Actions-AddNewIssueToColumn
 
-Create a card in any project column for a newly added issue. The project can be configured at the repository level or at the org level. This allows for new types of automations that are not currently supported with boards/issues.
+This action automatically adds issues or pull requests to a specific column in a project. A new project card gets created that references the issue or pull request if it doesn't already exist. 
+
+The project can be configured at the repository level or at the org level. This action allows you to create new types of automations that are not currently supported with project boards and issues.
 
 ### Demo
 
@@ -8,19 +10,25 @@ This demo shows a new issue called "Demo Issue" that automatically gets added to
 
 ![](demo.gif)
 
-### Description
-
-Github Action that is meant to automatically add a newly created issue to a specific column in a project. Example YAML workflow that will run whenever a new issue has been opened. The new issue that causes the workflow to run will be added to the specified column:
-
 ### Create a PAT with the appropriate permissions
 
-You have to use a custom token that has repo access. You can add that as a secret under the settings and use that instead of `secrets.GITHUB_TOKEN`. The token that is normally passed in does not have permissions to search projects to get the appropriate column id so it will fail with a `Resource not accessible by integration` error. If the project is setup at the org level (linked), it must also have `org:read` permissions to read projects at the org level.
+You have to use a custom token that has repo access when using a repository project board or `read:org` access if using an organization project board. You can add the PAT as a secret in the repository settings page and use it instead of `secrets.GITHUB_TOKEN`. The token that is normally passed in does not have permissions to search projects to get the appropriate column id so it will fail with a `Resource not accessible by integration` error.
 
 - Create a new personal access token with the appropriate permissions at https://github.com/settings/tokens
 - Add the personal access token to your repository secrets: https://github.com/organization_name/repository_name/settings/secrets (for an organization), https://github.com/repository_owner/repository_name/settings/secrets (for a standard repository), and remember the name
 - Use the newly saved token in your YAML file as input for `action-token`. In the example above, it is called `Access_token`
 
-### YAML
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `action-token` | Yes | A token with permissions to use repository or oraganization project board. |
+| `project-url`  | Yes | The full url of the GitHub project board. Ex. https://github.com/orgs/github/projects/1 |
+| `column-name`  | Yes | The name of the project board column where the issue or pull request should be added. |
+
+### Example workflow YAML
+
+Example YAML workflow that will run whenever a new issue has been opened. The new issue that causes the workflow to run will be added to the specified column:
 
 ```name: "New Issue Automation"
 on:
@@ -39,3 +47,44 @@ jobs:
 
 The project-url can be a repository project with a format like: `https://github.com/konradpabjan/example/projects/1` or a project linked at the org level with the following format: `https://github.com/orgs/exampleOrg/projects/1`
 
+### Conditionally running the workflow for issues or pull requests
+
+You can select which events trigger this action using the `on` workflow syntax. For example, starting a workflow file with the following YAML syntax will trigger the workflow when issues or pull requests are opened and reopened.
+
+```
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+```
+
+If your workflow triggers on both `issues` and pull_requests` but you'd like to limit a step to run on one of the events, you can use an `if` conditional.
+
+For example, if you had two separete project columns for issues and pull requests your workflow might look like this:
+
+```
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  Add_New_Issue_To_Project:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Triage pull requests
+      if: github.event_name == 'pull_request'
+      uses: konradpabjan/actions-add-new-issue-to-column@v1.1
+      with:
+        action-token: "${{ secrets.Access_token }}"
+        project-url: "https://github.com/orgs/github/projects/1"
+        column-name: "New pull requests should show up here"
+    - name: Triage issues
+      if: github.event_name == 'issues'
+      uses: konradpabjan/actions-add-new-issue-to-column@v1.1
+      with:
+        action-token: "${{ secrets.Access_token }}"
+        project-url: "https://github.com/orgs/github/projects/1"
+        column-name: "New issues should show up here"
+ ```

--- a/index.js
+++ b/index.js
@@ -7,31 +7,37 @@ async function run() {
     const projectUrl = core.getInput("project-url");
     const columnName = core.getInput("column-name");
     const octokit = new github.GitHub(myToken);
-    const context = github.context;
+    const payload = github.context.payload;
+    const contentType = payload.issue !== undefined ? "Issue" : "PullRequest";
+    const contentId = contentType === "Issue" ? 
+        payload.issue.id : payload.pull_request.id;
+    const contentNumber = contentType === "Issue" ? 
+        payload.issue.number : payload.pull_request.number;
 
-    console.log(`Action triggered by issue #${context.issue.number}`);
+    console.log(`Action triggered by ${contentType} #${contentNumber}`);
 
-    var info = await getColumnAndIssueInformation(columnName, projectUrl, myToken, context.payload.issue.id);
+    const info = await getColumnAndIssueInformation(columnName, projectUrl, myToken, contentId, contentType);
+
     if (info.cardId != null){
         return `No action being taken. A card already exists in the project for the issue. Column:${info.currentColumnName}, cardId:${info.cardId}.`;
     } else if(info.columnId != null) {
-        return await createNewCard(octokit, info.columnId, context.payload.issue.id);
+        return await createNewCard(octokit, info.columnId, contentId, contentType);
     } else {
         throw `Unable to find a columnId for the column ${columnName}, with Url:${projectUrl}`;
     }
 }
 
-async function createNewCard(octokit, columnId, issueId){
+async function createNewCard(octokit, columnId, issueId, contentType){
     console.log(`Attempting to create a card in column ${columnId}, for an issue with the corresponding id #${issueId}`);
     await octokit.projects.createCard({
         column_id: columnId,
         content_id: issueId,
-        content_type: "Issue"
+        content_type: contentType
     });
     return `Successfully created a new card in column #${columnId} for an issue with the corresponding id:${issueId} !`;
 }
 
-async function getColumnAndIssueInformation(columnName, projectUrl, token, issueDatabaseId){
+async function getColumnAndIssueInformation(columnName, projectUrl, token, contentDatabaseId, contentType){
     var columnId = null;
     var cardId = null;
     var currentColumnName = null;
@@ -43,7 +49,7 @@ async function getColumnAndIssueInformation(columnName, projectUrl, token, issue
         // Org url will be in the format: https://github.com/orgs/github/projects/910
         var orgLogin = splitUrl[4];
         console.log(`This project is configured at the org level. Org Login:${orgLogin}, project #${projectNumber}`);
-        var orgInformation = await getOrgInformation(orgLogin, projectNumber, token);
+        var orgInformation = await getOrgInformation(orgLogin, projectNumber, token, contentType);
         orgInformation.organization.project.columns.nodes.forEach(function(columnNode){
             if(columnNode.name == columnName){
                 columnId = columnNode.databaseId;
@@ -53,7 +59,7 @@ async function getColumnAndIssueInformation(columnName, projectUrl, token, issue
                 // card level
                 if (card.node.content != null){
                     // only issues and pull requests have content
-                    if(card.node.content.databaseId == issueDatabaseId){
+                    if(card.node.content.databaseId == contentDatabaseId){
                         cardId = card.node.databaseId;
                         currentColumnName = columnNode.name;
                     }
@@ -65,7 +71,7 @@ async function getColumnAndIssueInformation(columnName, projectUrl, token, issue
         var repoOwner = splitUrl[3];
         var repoName = splitUrl[4];
         console.log(`This project is configured at the repo level. Repo Owner:${repoOwner}, repo name:${repoName} project #${projectNumber}`);
-        var repoColumnInfo = await getRepoInformation(repoOwner, repoName, projectNumber, token);
+        var repoColumnInfo = await getRepoInformation(repoOwner, repoName, projectNumber, token, contentType);
         repoColumnInfo.repository.project.columns.nodes.forEach(function(columnNode){
             if(columnNode.name == columnName){
                 columnId = columnNode.databaseId;
@@ -75,7 +81,7 @@ async function getColumnAndIssueInformation(columnName, projectUrl, token, issue
                 // card level
                 if (card.node.content != null){
                     // only issues and pull requests have content
-                    if(card.node.content.databaseId == issueDatabaseId){
+                    if(card.node.content.databaseId == contentDatabaseId){
                         cardId = card.node.databaseId;
                         currentColumnName = columnNode.name;
                     }
@@ -89,7 +95,7 @@ async function getColumnAndIssueInformation(columnName, projectUrl, token, issue
         currentColumnName: currentColumnName};
 }
 
-async function getOrgInformation(organizationLogin, projectNumber, token){
+async function getOrgInformation(organizationLogin, projectNumber, token, contentType){
     // GraphQL query to get all of the cards in each column for a project
     // https://developer.github.com/v4/explorer/ is good to play around with
     const response = await graphql(
@@ -109,7 +115,7 @@ async function getOrgInformation(organizationLogin, projectNumber, token){
                                     node {
                                     databaseId
                                         content {
-                                            ... on Issue {
+                                            ... on ${contentType} {
                                                     databaseId
                                                     number
                                                 }
@@ -131,7 +137,7 @@ async function getOrgInformation(organizationLogin, projectNumber, token){
     return response;
 }
 
-async function getRepoInformation(repositoryOwner, repositoryName, projectNumber, token){
+async function getRepoInformation(repositoryOwner, repositoryName, projectNumber, token, contentType){
     // GraphQL query to get all of the columns in a project that is setup at that org level
     // https://developer.github.com/v4/explorer/ is good to play around with
     const response = await graphql(
@@ -152,7 +158,7 @@ async function getRepoInformation(repositoryOwner, repositoryName, projectNumber
                                     node {
                                         databaseId
                                         content {
-                                            ... on Issue {
+                                            ... on ${contentType} {
                                                 databaseId
                                                 number
                                                 }


### PR DESCRIPTION
@konradpabjan this pull requests add the capability to add both pull requests and issues as cards on a project board. I made some updates to the README to include the new behavior and to consolidate some of the description information into one section. Let me know if you have any feedback for the docs or the code updates! I'm not sure if this would cause a breaking change to folks who have workflows that listen for both pull requests and issues already. 